### PR TITLE
Switch to dockerhub

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Login to GitHub Docker Registry
-        run: docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+        run: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/base/Makefile
+++ b/base/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-REGISTRY=docker.pkg.github.com/skpr/containers/base
+REGISTRY=skpr/base
 
 build:
 	docker build -t $(REGISTRY):1.x .

--- a/kubebuilder/Makefile
+++ b/kubebuilder/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-REGISTRY=docker.pkg.github.com/skpr/containers/kubebuilder
+REGISTRY=skpr/kubebuilder
 
 build:
 	docker build -t $(REGISTRY):v1.0.6 .

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-REGISTRY=docker.pkg.github.com/skpr/containers/nginx
+REGISTRY=skpr/nginx
 
 build:
 	docker build -t $(REGISTRY):1.x .

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-REGISTRY=docker.pkg.github.com/skpr/containers/node
+REGISTRY=skpr/node
 
 build:
 	docker build -t $(REGISTRY):10-1.x .

--- a/php/Makefile
+++ b/php/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-REGISTRY=docker.pkg.github.com/skpr/containers/php
+REGISTRY=skpr/php
 
 define build_image
 	# Building production images.

--- a/solr/Makefile
+++ b/solr/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-REGISTRY=docker.pkg.github.com/skpr/containers/solr
+REGISTRY=skpr/solr
 
 build:
 	docker build -t $(REGISTRY):init init


### PR DESCRIPTION
Github's docker repository requires authentication for public images. 

We should stick with dockerhub for now.