### PR TITLE
Add deploy status

### DIFF
--- a/php/cli/Dockerfile
+++ b/php/cli/Dockerfile
@@ -19,6 +19,9 @@ RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
     chmod +x /usr/local/bin/composer
 
+RUN curl -sSL https://github.com/previousnext/go-deploy-status/releases/download/1.0.0-alpha3/deploy-status_linux_amd64 -o /usr/local/bin/deploy-status \
+  && chmod a+x /usr/local/bin/deploy-status
+
 ADD drush /etc/drush
 
 USER skpr


### PR DESCRIPTION
https://github.com/previousnext/go-deploy-status is a nice integration with Github which lets you track which specific commits were deployed to which environment and at what time. You can see them see them on your repo page under `/deployments` (labelled 'Environments'). This provides a useful deployment history.