### PR TITLE
Bump fastcgi_buffers and fastcgi_buffer_size

### DIFF
--- a/nginx/dev/default.conf
+++ b/nginx/dev/default.conf
@@ -94,6 +94,10 @@ server {
         fastcgi_param HTTPS $cloudfront_https;
         fastcgi_intercept_errors on;
         fastcgi_read_timeout 300;
+
+        # Bump the buffer size to accomodate large headers on local environments.
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 16k;
     }
 
     location ~ ^/sites/.*/files/styles/ {


### PR DESCRIPTION
For dev image to accomodate large headers from Drupal cache debugging

http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers