### PR TITLE
[CLAMAV] Prime data for local development and CI pipelines

### DIFF
--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -6,11 +6,14 @@ COPY clamd.conf /etc/clamav/clamd.conf
 RUN mkdir -p /run/clamav /var/lib/clamav /var/log/clamav && \
     chown -R skpr:skpr /run/clamav /var/lib/clamav /var/log/clamav
 
+USER skpr
+
+# Prime the caches for local development and CI pipelines.
+RUN freshclam --verbose --stdout
+
 VOLUME /run/clamav
 VOLUME /var/lib/clamav
 VOLUME /var/log/clamav
-
-USER skpr
 
 EXPOSE 3310
 


### PR DESCRIPTION
**Issue**

* Our ClamAV image doesn't ship with some base databases.
* Local development and CI environments expect a service to come up with `docker run -it skpr/clamav:latest`
* This results on those environments not starting.

**Solution**

Add the `freshclam` command to the Dockerfile and execute it prior to `Volume` definitions so it's data is captured.