### PR TITLE
Remove php workers decoration

### DIFF
--- a/php/circleci/fpm/php-fpm.conf
+++ b/php/circleci/fpm/php-fpm.conf
@@ -20,6 +20,7 @@ access.log = /proc/self/fd/2
 clear_env = no
 
 catch_workers_output = yes
+decorate_workers_output = no
 
 request_terminate_timeout = 300
 

--- a/php/fpm/php-fpm.conf
+++ b/php/fpm/php-fpm.conf
@@ -21,6 +21,7 @@ access.log = /proc/self/fd/2
 clear_env = no
 
 catch_workers_output = yes
+decorate_workers_output = no
 
 request_terminate_timeout = 60
 


### PR DESCRIPTION
```
php-fpm_1         | [2020-04-08 16:44:56] content.NOTICE: basic: added dfgdfgdfg. {"link":"[object] (Drupal\\Core\\GeneratedLink: \"<a href=\\\"/dfgdfgdfg\\\" hreflang=\\\"en\\\">View</a>\")"} {"referer":"","ip":"172.22.0.1","request_uri":"http://127.0.0.1:8080/node/add/basic","uid":"1","user":"admin"}
```