### PR TITLE
Allow http level config overrides

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,6 +7,7 @@ ADD default.conf /etc/nginx/conf.d/default.conf
 ADD status.conf /etc/nginx/conf.d/status.conf
 ADD security.conf /etc/nginx/conf.d/security.conf
 RUN touch /etc/nginx/conf.d/custom.conf
+RUN touch /etc/nginx/conf.d/http.conf
 RUN touch /etc/nginx/redirects.conf
 
 # We need to create and chown these directory for

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -17,6 +17,8 @@ map $host$uri $redirectdomain {
   include /etc/nginx/redirects.conf;
 }
 
+include /etc/nginx/conf.d/http.conf;
+
 server {
     listen 8080;
 

--- a/nginx/dev/default.conf
+++ b/nginx/dev/default.conf
@@ -17,6 +17,8 @@ map $host$uri $redirectdomain {
   include /etc/nginx/redirects.conf;
 }
 
+include /etc/nginx/conf.d/http.conf;
+
 server {
     listen 8080;
     


### PR DESCRIPTION
So we can do fun things like this for certain projects that have wacky requirements:

```
# Map http_origin concatenated with $request_uri into CORS headers.
# $cors_header used in nginx.conf to add the header.
map $http_origin$request_uri $cors_header {
  default "";
  "~^https?://(my\.service\.nsw\.gov\.au|(.*snsw|.*servicensw.*)\..*\.force\.com)(:\d+)?/privacy$" "$http_origin";
}
```