### PR TITLE
Set default_type on .well-known files

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -57,6 +57,7 @@ server {
 
     location ~* ^/.well-known/ {
         allow all;
+        default_type application/json;
     }
 
     location ~ (^|/)\. {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -55,9 +55,12 @@ server {
         deny all;
     }
 
+    location ~* ^/(\.well-known/)?apple-app-site-association {
+        default_type application/json;
+    }
+
     location ~* ^/.well-known/ {
         allow all;
-        default_type application/json;
     }
 
     location ~ (^|/)\. {

--- a/nginx/dev/default.conf
+++ b/nginx/dev/default.conf
@@ -57,6 +57,7 @@ server {
 
     location ~* ^/.well-known/ {
         allow all;
+        default_type application/json;
     }
 
     location ~ (^|/)\. {

--- a/nginx/dev/default.conf
+++ b/nginx/dev/default.conf
@@ -55,9 +55,12 @@ server {
         deny all;
     }
 
+    location ~* ^/(\.well-known/)?apple-app-site-association {
+        default_type application/json;
+    }
+
     location ~* ^/.well-known/ {
         allow all;
-        default_type application/json;
     }
 
     location ~ (^|/)\. {

--- a/php/circleci/nginx/default.conf
+++ b/php/circleci/nginx/default.conf
@@ -53,9 +53,12 @@ server {
         deny all;
     }
 
+    location ~* ^/(\.well-known/)?apple-app-site-association {
+        default_type application/json;
+    }
+
     location ~* ^/.well-known/ {
         allow all;
-        default_type application/json;
     }
 
     location ~ (^|/)\. {

--- a/php/circleci/nginx/default.conf
+++ b/php/circleci/nginx/default.conf
@@ -55,6 +55,7 @@ server {
 
     location ~* ^/.well-known/ {
         allow all;
+        default_type application/json;
     }
 
     location ~ (^|/)\. {


### PR DESCRIPTION
Fixes an issue with nginx downloading the `/.well-known/apple-app-site-association` file.

This file cannot be suffixed with `.json` as per [apple's doco](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) and currently it is being served as `application/octet-stream` which the browser downloads.