### PR TITLE
Add user for www pool

### DIFF
--- a/php/circleci/fpm/php-fpm.conf
+++ b/php/circleci/fpm/php-fpm.conf
@@ -3,7 +3,7 @@ error_log = /proc/self/fd/2
 
 [www]
 listen = [::]:${PHP_FPM_PORT}
-
+user = skpr
 chdir = /data/app
 
 pm = dynamic


### PR DESCRIPTION
Seeing `ALERT: [pool www] user has not been defined` in latest builds which results in PHP-FPM fatal