### PR TITLE
Local dev nginx rewrites sites/default/files

### DIFF
--- a/nginx/dev/default.conf
+++ b/nginx/dev/default.conf
@@ -106,7 +106,7 @@ server {
         fastcgi_buffer_size 16k;
     }
 
-    location ~ ^/sites/.*/files/styles/ {
+    location ~ ^/sites/.*/files/ {
         try_files $uri @rewrite;
     }
 


### PR DESCRIPTION
Allow Drupal to handle 404s on `sites/default/files` (not just `styles`) so that `stage_file_proxy` works.