### PR TITLE
Add zlib to support Ne-Lexa/php-zip

### DIFF
--- a/php/base/Dockerfile
+++ b/php/base/Dockerfile
@@ -54,6 +54,7 @@ RUN apk --update --no-cache add \
       php${PHP_VERSION}-xml \
       php${PHP_VERSION}-xmlreader \
       php${PHP_VERSION}-xmlwriter \
+      php${PHP_VERSION}-zlib \
       php${PHP_VERSION}-zip \
       pngquant \
       jpegoptim \


### PR DESCRIPTION
Ne-Lexa/php-zip requires ext-zlib

Whilst it works (without compression) without it, it would be nice to not need to fork it just to remove that requirement.