### PR TITLE
Install libvips from source

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -18,6 +18,24 @@ RUN apk add --no-cache \
   nasm \
   util-linux
 
+# Install latest version of libvips from source.
+# Gatsby 3 requires sharp 0.27.0 or higher.
+# sharp requires libvips 8.10.5 or higher.
+# Only Alpine 3.13 has libvips 8.10+ available via apk.
+RUN apk --update --no-cache add glib-dev \
+  expat-dev \
+  jpeg-dev
+RUN cd /tmp && \
+  wget https://github.com/libvips/libvips/releases/download/v8.10.6/vips-8.10.6.tar.gz
+RUN cd /tmp && \
+  tar -xzvf vips-8.10.6.tar.gz
+RUN cd /tmp/vips-8.10.6 && \
+  ./configure
+RUN cd /tmp/vips-8.10.6 && \
+ make
+RUN cd /tmp/vips-8.10.6 && \
+  make install
+RUN rm -rf /tmp/vips-8.10.6
 
 RUN deluser node
 RUN adduser -D -u 1000 skpr

--- a/php/circleci/Dockerfile
+++ b/php/circleci/Dockerfile
@@ -54,6 +54,25 @@ RUN apk --update --no-cache add bash \
   libtool \
   nasm
 
+# Install latest version of libvips from source.
+# Gatsby 3 requires sharp 0.27.0 or higher.
+# sharp requires libvips 8.10.5 or higher.
+# Only Alpine 3.13 has libvips 8.10+ available via apk.
+RUN apk --update --no-cache add glib-dev \
+  expat-dev \
+  jpeg-dev
+RUN cd /tmp && \
+  wget https://github.com/libvips/libvips/releases/download/v8.10.6/vips-8.10.6.tar.gz
+RUN cd /tmp && \
+  tar -xzvf vips-8.10.6.tar.gz
+RUN cd /tmp/vips-8.10.6 && \
+  ./configure
+RUN cd /tmp/vips-8.10.6 && \
+ make
+RUN cd /tmp/vips-8.10.6 && \
+  make install
+RUN rm -rf /tmp/vips-8.10.6
+
 COPY --chown=skpr:skpr --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --chown=skpr:skpr --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --chown=skpr:skpr --from=node /opt /opt


### PR DESCRIPTION
Gatsby v3+ requires sharp 0.27.0+
sharp 0.27.0+ requires libvips 8.10+
Alpine < 3.13 doesn't have that available to apk
So we need to install it from source

Sample `npm ci` output

```bash
info sharp Detected globally-installed libvips v8.10.6
info sharp Building from source via node-gyp
```