### PR TITLE
Libvips prebuilt

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -16,7 +16,10 @@ RUN apk add --no-cache \
   libpng-dev \
   libtool \
   nasm \
-  util-linux
+  util-linux \
+  glib-dev \
+  expat-dev \
+  jpeg-dev
 
 RUN mkdir -p /usr/local/lib
 ADD binaries/lib-vips-8.10.6-linuxmusl-x64.tar.gz /usr/local/lib

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -18,24 +18,8 @@ RUN apk add --no-cache \
   nasm \
   util-linux
 
-# Install latest version of libvips from source.
-# Gatsby 3 requires sharp 0.27.0 or higher.
-# sharp requires libvips 8.10.5 or higher.
-# Only Alpine 3.13 has libvips 8.10+ available via apk.
-RUN apk --update --no-cache add glib-dev \
-  expat-dev \
-  jpeg-dev
-RUN cd /tmp && \
-  wget https://github.com/libvips/libvips/releases/download/v8.10.6/vips-8.10.6.tar.gz
-RUN cd /tmp && \
-  tar -xzvf vips-8.10.6.tar.gz
-RUN cd /tmp/vips-8.10.6 && \
-  ./configure
-RUN cd /tmp/vips-8.10.6 && \
- make
-RUN cd /tmp/vips-8.10.6 && \
-  make install
-RUN rm -rf /tmp/vips-8.10.6
+RUN mkdir -p /usr/local/lib
+ADD binaries/lib-vips-8.10.6-linuxmusl-x64.tar.gz /usr/local/lib
 
 RUN deluser node
 RUN adduser -D -u 1000 skpr

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -18,6 +18,24 @@ RUN apk add --no-cache \
   nasm \
   util-linux
 
+# Install latest version of libvips from source.
+# Gatsby 3 requires sharp 0.27.0 or higher.
+# sharp requires libvips 8.10.5 or higher.
+# Only Alpine 3.13 has libvips 8.10+ available via apk.
+RUN apk --update --no-cache add glib-dev \
+  expat-dev \
+  jpeg-dev
+RUN cd /tmp && \
+  wget https://github.com/libvips/libvips/releases/download/v8.10.6/vips-8.10.6.tar.gz
+RUN cd /tmp && \
+  tar -xzvf vips-8.10.6.tar.gz
+RUN cd /tmp/vips-8.10.6 && \
+  ./configure
+RUN cd /tmp/vips-8.10.6 && \
+ make
+RUN cd /tmp/vips-8.10.6 && \
+  make install
+RUN rm -rf /tmp/vips-8.10.6
 
 RUN deluser node
 RUN adduser -D -u 1000 skpr

--- a/php/circleci/Dockerfile
+++ b/php/circleci/Dockerfile
@@ -54,6 +54,25 @@ RUN apk --update --no-cache add bash \
   libtool \
   nasm
 
+# Install latest version of libvips from source.
+# Gatsby 3 requires sharp 0.27.0 or higher.
+# sharp requires libvips 8.10.5 or higher.
+# Only Alpine 3.13 has libvips 8.10+ available via apk.
+RUN apk --update --no-cache add glib-dev \
+  expat-dev \
+  jpeg-dev
+RUN cd /tmp && \
+  wget https://github.com/libvips/libvips/releases/download/v8.10.6/vips-8.10.6.tar.gz
+RUN cd /tmp && \
+  tar -xzvf vips-8.10.6.tar.gz
+RUN cd /tmp/vips-8.10.6 && \
+  ./configure
+RUN cd /tmp/vips-8.10.6 && \
+ make
+RUN cd /tmp/vips-8.10.6 && \
+  make install
+RUN rm -rf /tmp/vips-8.10.6
+
 COPY --chown=skpr:skpr --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --chown=skpr:skpr --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --chown=skpr:skpr --from=node /opt /opt

--- a/php/circleci/Dockerfile
+++ b/php/circleci/Dockerfile
@@ -52,7 +52,10 @@ RUN apk --update --no-cache add bash \
   automake \
   libpng-dev \
   libtool \
-  nasm
+  nasm \
+  glib-dev \
+  expat-dev \
+  jpeg-dev
 
 COPY --from=node /usr/local/lib/libvips* /usr/local/lib/
 COPY --from=node /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig

--- a/php/circleci/Dockerfile
+++ b/php/circleci/Dockerfile
@@ -54,25 +54,7 @@ RUN apk --update --no-cache add bash \
   libtool \
   nasm
 
-# Install latest version of libvips from source.
-# Gatsby 3 requires sharp 0.27.0 or higher.
-# sharp requires libvips 8.10.5 or higher.
-# Only Alpine 3.13 has libvips 8.10+ available via apk.
-RUN apk --update --no-cache add glib-dev \
-  expat-dev \
-  jpeg-dev
-RUN cd /tmp && \
-  wget https://github.com/libvips/libvips/releases/download/v8.10.6/vips-8.10.6.tar.gz
-RUN cd /tmp && \
-  tar -xzvf vips-8.10.6.tar.gz
-RUN cd /tmp/vips-8.10.6 && \
-  ./configure
-RUN cd /tmp/vips-8.10.6 && \
- make
-RUN cd /tmp/vips-8.10.6 && \
-  make install
-RUN rm -rf /tmp/vips-8.10.6
-
+COPY --from=node /usr/local/lib/libvips* /usr/local/lib/
 COPY --chown=skpr:skpr --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --chown=skpr:skpr --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --chown=skpr:skpr --from=node /opt /opt

--- a/php/circleci/Dockerfile
+++ b/php/circleci/Dockerfile
@@ -55,6 +55,7 @@ RUN apk --update --no-cache add bash \
   nasm
 
 COPY --from=node /usr/local/lib/libvips* /usr/local/lib/
+COPY --from=node /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig
 COPY --chown=skpr:skpr --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --chown=skpr:skpr --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --chown=skpr:skpr --from=node /opt /opt


### PR DESCRIPTION
Gatsby v3+ requires sharp 0.27.0+
sharp 0.27.0+ requires libvips 8.10+
Alpine < 3.13 doesn't have that available to apk
See #107 for a build from source approach

This PR instead swaps in pre-built binaries.

Question is, is a 14MB binary in the repo better than building from source?

Given it takes 3 minutes to compile from source on my local, I'd say 💯 
