### PR TITLE
Fixes 'Wrong charset' iconv issue

### DIFF
--- a/php/base/Dockerfile
+++ b/php/base/Dockerfile
@@ -14,13 +14,15 @@ ENV SYSLOG_SYMLINK=/mnt/syslog/log
 
 ENV PATH "$PATH:/data/bin"
 
+ENV LD_PRELOAD "/usr/lib/preloadable_libiconv.so php"
+
 # https://github.com/moby/moby/issues/20295
 RUN mkdir /data && \
     chown -R skpr:skpr /data
 
 WORKDIR /data
 
-RUN apk add --no-cache curl ca-certificates && \
+RUN apk add --no-cache curl ca-certificates gnu-libiconv && \
     curl -sSL https://packages.skpr.io/php-alpine/skpr.rsa.pub -o /etc/apk/keys/skpr.rsa.pub && \
     echo "https://packages.skpr.io/php-alpine/${ALPINE_VERSION}/php${PHP_VERSION}" >> /etc/apk/repositories
 

--- a/php/base/tests.yml
+++ b/php/base/tests.yml
@@ -10,5 +10,5 @@ commandTests:
   - name:  "iconv"
     command: "php"
     args: ["-r", "iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'šěýčíéáýřčíšýíščř');"]
-    expectedOutput: [""]
+    excludedError: ['.*Wrong charset.*']
     exitCode: 0

--- a/php/base/tests.yml
+++ b/php/base/tests.yml
@@ -6,3 +6,9 @@ commandTests:
     args: ["--help"]
     expectedError: ["Usage of docconv"]
     exitCode: 0
+
+  - name:  "iconv"
+    command: "php"
+    args: ["-r", "iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'šěýčíéáýřčíšýíščř');"]
+    expectedOutput: [""]
+    exitCode: 0

--- a/php/fpm/Dockerfile
+++ b/php/fpm/Dockerfile
@@ -12,6 +12,8 @@ EXPOSE 9000
 
 USER skpr
 
+ENV LD_PRELOAD "/usr/lib/preloadable_libiconv.so php-fpm"
+
 # Configuration which can be overriden.
 # See /etc/php/php-fpm.conf
 ENV PHP_FPM_PORT=9000 \


### PR DESCRIPTION
Can be tested with:

```
>>> $mb_name = "\U+DFE6\U+DFB9\U+DF8A\U+DFE5\U+DFB4\U+DF8E \U+DFE7\U+DFB4\U+DF97\U+DFE5\U+DFA4\U+DF8F";
=> "湊崎 紗夏"
>>> $tmp_mb_name = iconv('UTF-8', 'UTF-8//IGNORE', $mb_name);
PHP Notice:  iconv(): Wrong charset, conversion from `UTF-8' to `UTF-8//IGNORE' is not allowed in Psy Shell code on line 1
=> false
```