### PR TITLE
Add Cache-Control header to FPM logging

### DIFF
--- a/php/fpm/php-fpm.conf
+++ b/php/fpm/php-fpm.conf
@@ -16,7 +16,7 @@ pm.max_requests      = ${PHP_FPM_MAX_REQUESTS}
 
 pm.status_path = /status
 
-access.format='{ "timestamp": "%{%Y-%m-%dT%H:%M:%S%z}T", "fields": { "client_ip": "%{HTTP_X_FORWARDED_FOR}e", "remote_addr": "%R", "remote_user": "%u", "request_uri": "%{REQUEST_URI}e", "status": "%s", "body_bytes_sent": "%l", "request_time": "%d", "http_referrer": "%{HTTP_REFERER}e", "http_user_agent": "%{HTTP_USER_AGENT}e", "request_id": "%{HTTP_X_REQUEST_ID}e", "cpu": "%C", "memory": "%M" } }'
+access.format='{ "timestamp": "%{%Y-%m-%dT%H:%M:%S%z}T", "fields": { "client_ip": "%{HTTP_X_FORWARDED_FOR}e", "remote_addr": "%R", "remote_user": "%u", "request_uri": "%{REQUEST_URI}e", "status": "%s", "body_bytes_sent": "%l", "request_time": "%d", "http_referrer": "%{HTTP_REFERER}e", "http_user_agent": "%{HTTP_USER_AGENT}e", "request_id": "%{HTTP_X_REQUEST_ID}e", "cpu": "%C", "memory": "%M", "headers": { "Cache-Control": "%{Cache-Control}o"} } }'
 access.log = /proc/self/fd/2
 
 clear_env = no


### PR DESCRIPTION
This PR adds the `Cache-Control` header to FPM logging.

Example of structure:

```json
{ "timestamp": "2021-09-09T06:26:38+0000", "fields": { "client_ip": "-", "remote_addr": "127.0.0.1", "remote_user": "", "request_uri": "/", "status": "200", "body_bytes_sent": "0", "request_time": "0.063", "http_referrer": "", "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0", "request_id": "-", "cpu": "79.76", "memory": "6291456", "headers": { "Cache-Control": "max-age=600, public"} } }
```