### PR TITLE
Allow writer to delete local indices.

### DIFF
--- a/opensearch/dev/roles.yml
+++ b/opensearch/dev/roles.yml
@@ -21,6 +21,7 @@ writer:
       allowed_actions:
         - "indices:admin/create"
         - "indices:admin/get"
+        - "indices:admin/delete"
         - "indices:admin/mapping/put"
         - "indices:data/read/search"
         - "indices:data/write/bulk"


### PR DESCRIPTION
Datapiplines sends the delete indices request when the dataset is deleted. cc: @nickschuch @nterbogt

