### PR TITLE
add node 16 container to skpr/php-circleci as 3.x

### DIFF
--- a/php/Makefile
+++ b/php/Makefile
@@ -23,9 +23,12 @@ build: validate
 	docker build --no-cache --build-arg PHP_VERSION=$(PHP_VERSION) --build-arg IMAGE=$(REGISTRY)-cli:$(PHP_VERSION)-1.x-dev -t $(REGISTRY)-cli:$(PHP_VERSION)-1.x-xdebug xdebug
 	
 	# Building CircleCI images.
-	docker build --no-cache --build-arg PHP_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=$(NODE_VERSION) -t $(REGISTRY)-circleci:$(PHP_VERSION)-1.x circleci
-	# 1.x version is Node 10, 2.x is Node 14.
+	# 1.x version is Node 10.
+	docker build --no-cache --build-arg PHP_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=$(NODE_VERSION) -t $(REGISTRY)-circleci:$(PHP_VERSION)-1.x circleci 
+	# 2.x is Node 14.
 	docker build --no-cache --build-arg PHP_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=14-1.x -t $(REGISTRY)-circleci:$(PHP_VERSION)-2.x circleci
+	# 3.x is Node 16.
+	docker build --no-cache --build-arg PHP_VERSION=$(PHP_VERSION) --build-arg NODE_VERSION=16-1.x -t $(REGISTRY)-circleci:$(PHP_VERSION)-3.x circleci
 
 push: validate
 	# Pushing production images
@@ -44,6 +47,7 @@ push: validate
 	# Pushing CircleCI images.
 	docker push $(REGISTRY)-circleci:$(PHP_VERSION)-1.x
 	docker push $(REGISTRY)-circleci:$(PHP_VERSION)-2.x
+	docker push $(REGISTRY)-circleci:$(PHP_VERSION)-3.x
 
 validate:
 ifndef PHP_VERSION


### PR DESCRIPTION
Doesn't look like we have a version of `php-circleci` that has node 16.